### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/wandb/run-20250328_084916-0vm0pdwc/files/requirements.txt
+++ b/wandb/run-20250328_084916-0vm0pdwc/files/requirements.txt
@@ -190,7 +190,7 @@ langchain-community==0.3.17
 typing-inspect==0.9.0
 PyPika==0.48.9
 dill==0.3.8
-pyautogen==0.8.2
+ag2==0.8.2
 fonttools==4.56.0
 pydeck==0.9.1
 tomli==2.2.1

--- a/wandb/run-20250328_091616-gc0pbgf9/files/requirements.txt
+++ b/wandb/run-20250328_091616-gc0pbgf9/files/requirements.txt
@@ -190,7 +190,7 @@ langchain-community==0.3.17
 typing-inspect==0.9.0
 PyPika==0.48.9
 dill==0.3.8
-pyautogen==0.8.2
+ag2==0.8.2
 fonttools==4.56.0
 pydeck==0.9.1
 tomli==2.2.1

--- a/wandb/run-20250328_100906-vt81cwa2/files/requirements.txt
+++ b/wandb/run-20250328_100906-vt81cwa2/files/requirements.txt
@@ -190,7 +190,7 @@ langchain-community==0.3.17
 typing-inspect==0.9.0
 PyPika==0.48.9
 dill==0.3.8
-pyautogen==0.8.2
+ag2==0.8.2
 fonttools==4.56.0
 pydeck==0.9.1
 tomli==2.2.1

--- a/wandb/run-20250328_163438-ppppepqa/files/requirements.txt
+++ b/wandb/run-20250328_163438-ppppepqa/files/requirements.txt
@@ -195,7 +195,7 @@ langchain-community==0.3.17
 typing-inspect==0.9.0
 PyPika==0.48.9
 dill==0.3.8
-pyautogen==0.8.2
+ag2==0.8.2
 fonttools==4.56.0
 pydeck==0.9.1
 tomli==2.2.1

--- a/wandb/run-20250328_163552-s2rftq0y/files/requirements.txt
+++ b/wandb/run-20250328_163552-s2rftq0y/files/requirements.txt
@@ -195,7 +195,7 @@ langchain-community==0.3.17
 typing-inspect==0.9.0
 PyPika==0.48.9
 dill==0.3.8
-pyautogen==0.8.2
+ag2==0.8.2
 fonttools==4.56.0
 pydeck==0.9.1
 tomli==2.2.1

--- a/wandb/run-20250330_145100-w6qdgfao/files/requirements.txt
+++ b/wandb/run-20250330_145100-w6qdgfao/files/requirements.txt
@@ -195,7 +195,7 @@ langchain-community==0.3.17
 typing-inspect==0.9.0
 PyPika==0.48.9
 dill==0.3.8
-pyautogen==0.8.2
+ag2==0.8.2
 fonttools==4.56.0
 pydeck==0.9.1
 tomli==2.2.1

--- a/wandb/run-20250330_154502-wgzd1vik/files/requirements.txt
+++ b/wandb/run-20250330_154502-wgzd1vik/files/requirements.txt
@@ -195,7 +195,7 @@ langchain-community==0.3.17
 typing-inspect==0.9.0
 PyPika==0.48.9
 dill==0.3.8
-pyautogen==0.8.2
+ag2==0.8.2
 fonttools==4.56.0
 pydeck==0.9.1
 tomli==2.2.1

--- a/wandb/run-20250330_154621-c91ssubd/files/requirements.txt
+++ b/wandb/run-20250330_154621-c91ssubd/files/requirements.txt
@@ -195,7 +195,7 @@ langchain-community==0.3.17
 typing-inspect==0.9.0
 PyPika==0.48.9
 dill==0.3.8
-pyautogen==0.8.2
+ag2==0.8.2
 fonttools==4.56.0
 pydeck==0.9.1
 tomli==2.2.1

--- a/wandb/run-20250330_154723-xjt7at6x/files/requirements.txt
+++ b/wandb/run-20250330_154723-xjt7at6x/files/requirements.txt
@@ -195,7 +195,7 @@ langchain-community==0.3.17
 typing-inspect==0.9.0
 PyPika==0.48.9
 dill==0.3.8
-pyautogen==0.8.2
+ag2==0.8.2
 fonttools==4.56.0
 pydeck==0.9.1
 tomli==2.2.1


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
